### PR TITLE
Titles were remove from navbar in login page

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -27,6 +27,7 @@
         <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
               <span class="navbar-toggler-icon"></span>
             </button>
+        {% if user.is_authenticated %}
         <div class="collapse navbar-collapse" id="navbarResponsive">
           <ul class="navbar-nav ml-auto">
             <li class="nav-item active d-flex">
@@ -48,6 +49,7 @@
             </li>
           </ul>
         </div>
+        {% endif %}
       </div>
     </nav>
     {% block content %}


### PR DESCRIPTION
Now when a user isn't logged in the navbar only shows Eventbrite logo and Upfronts tittle. Contracts, Installments and log out aren't show anymore.